### PR TITLE
Add MODE for PLL_CORE primitive for LIFCL-17

### DIFF
--- a/LIFCL/tiletypes/GPLL_LLC_15K.ron
+++ b/LIFCL/tiletypes/GPLL_LLC_15K.ron
@@ -158,6 +158,13 @@
         "LMMIRESETN": [],
       },
     ),
+    "PLL_LLC.MODE": (
+      options: {
+        "NONE": [],
+        "PLL_CORE": [(frame:40,bit:0,invert:false,),],
+      },
+      desc: "PLL_CORE primitive mode",
+    ),
   },
   conns: {
     "G:JLLCLKOP_BMID_CORE_BMIDMUX": [

--- a/LIFCL/tiletypes/GPLL_LRC_15K.ron
+++ b/LIFCL/tiletypes/GPLL_LRC_15K.ron
@@ -158,6 +158,13 @@
         "LMMIRESETN": [],
       },
     ),
+    "PLL_LRC.MODE": (
+      options: {
+        "NONE": [],
+        "PLL_CORE": [(frame:40,bit:0,invert:false,),],
+      },
+      desc: "PLL_CORE primitive mode",
+    ),
   },
   conns: {
     "G:JLRCLKOP_BMID_CORE_BMIDMUX": [


### PR DESCRIPTION
It looks like this was fuzzer regressed during time since LIFCL-40 does not fuzz this bit nigher.

Bit /frame location is bit different but was confirmed using lattice tools.

This should fix https://github.com/gatecat/prjoxide/issues/44

EDIT: Will work on fixing actual code, but would be nice to confirm that generated data is good
